### PR TITLE
add support for title H1..H6

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,9 @@ Allows you to use shortcuts to edit Markdown (`.md`, `.markdown`) files.
 | md-shortcut.toggleInlineCode | Make \`inline code\` | ctrl+M ctrl+I |
 | md-shortcut.toggleBullets | Make * bullet point | ctrl+M ctrl+B |
 | md-shortcut.toggleNumbers | Make 1. numbered list | ctrl+M ctrl+1 |
+| md-shortcut.toggleTitleH1 | Toggle title H1 |  |
+| md-shortcut.toggleTitleH2 | Toggle title H2 |  |
+| md-shortcut.toggleTitleH3 |Toggle title H3 |  |
+| md-shortcut.toggleTitleH4 | Toggle title H4 |  |
+| md-shortcut.toggleTitleH5 | Toggle title H5 |  |
+| md-shortcut.toggleTitleH6 | Toggle title H6 |  |

--- a/commands.js
+++ b/commands.js
@@ -12,11 +12,12 @@ var _commands = [
     new Command('toggleLink', toggleLink, 'Toggle hyperlink', '[Link text](link_url)', true),
     new Command('toggleBullets', toggleBullets, 'Toggle bullet points', '* Bullet point', true),
     new Command('toggleNumbers', toggleNumberList, 'Toggle number list', '1 Numbered list item', true),
+    new Command('toggleTitleH1', toggleTitleH1, 'Toggle title H1', '# Title', true),
     new Command('toggleTitleH2', toggleTitleH2, 'Toggle title H2', '## Title', true),
     new Command('toggleTitleH3', toggleTitleH3, 'Toggle title H3', '### Title', true),
     new Command('toggleTitleH4', toggleTitleH4, 'Toggle title H4', '#### Title', true),
     new Command('toggleTitleH5', toggleTitleH5, 'Toggle title H5', '##### Title', true),
-    new Command('toggleTitleH6', toggleTitleH6, 'Toggle title H6', '###### Title', true),
+    new Command('toggleTitleH6', toggleTitleH6, 'Toggle title H6', '###### Title', true)
 ]
 
 function register(context) {
@@ -51,6 +52,10 @@ function toggleCodeBlock() {
 
 function toggleInlineCode() {
     surroundSelection('`')
+}
+
+function toggleTitleH1() {
+    surroundSelection('# ','')
 }
 
 function toggleTitleH2() {

--- a/commands.js
+++ b/commands.js
@@ -11,7 +11,12 @@ var _commands = [
     new Command('toggleInlineCode', toggleInlineCode, 'Toggle inline code', '`Inline code`', true),
     new Command('toggleLink', toggleLink, 'Toggle hyperlink', '[Link text](link_url)', true),
     new Command('toggleBullets', toggleBullets, 'Toggle bullet points', '* Bullet point', true),
-    new Command('toggleNumbers', toggleNumberList, 'Toggle number list', '1 Numbered list item', true)
+    new Command('toggleNumbers', toggleNumberList, 'Toggle number list', '1 Numbered list item', true),
+    new Command('toggleTitleH2', toggleTitleH2, 'Toggle title H2', '## Title', true),
+    new Command('toggleTitleH3', toggleTitleH3, 'Toggle title H3', '### Title', true),
+    new Command('toggleTitleH4', toggleTitleH4, 'Toggle title H4', '#### Title', true),
+    new Command('toggleTitleH5', toggleTitleH5, 'Toggle title H5', '##### Title', true),
+    new Command('toggleTitleH6', toggleTitleH6, 'Toggle title H6', '###### Title', true),
 ]
 
 function register(context) {
@@ -46,6 +51,26 @@ function toggleCodeBlock() {
 
 function toggleInlineCode() {
     surroundSelection('`')
+}
+
+function toggleTitleH2() {
+    surroundSelection('## ','')
+}
+
+function toggleTitleH3() {
+    surroundSelection('### ','')
+}
+
+function toggleTitleH4() {
+    surroundSelection('#### ','')
+}
+
+function toggleTitleH5() {
+    surroundSelection('##### ','')
+}
+
+function toggleTitleH6() {
+    surroundSelection('###### ','')
 }
 
 var HasBullets = /^(\s*)\* (.*)$/gm


### PR DESCRIPTION
Hi, I find your extension really helpful, it saves me much time when I write on my static blog (where pages and posts are markdown). 

I added the support for the formatting of the titles (from H1 to H6). I have not experience at all with Javascript, so I made the simplest choice: I reused your function `surroundSelection()` .

Though, since they are 6 types of titles, I didn't add any shortcut to the Ctrl+M (because the most intuitive one would have been Ctrl+M Ctrl+H .. but then, how to differentiate the different H1..H6?). I actually find it faster to just type `Ctrl+M Ctrl+M` to have all the shortcuts, and then just type _Title_ and choose the one I prefer from the menu. 

Anyway, I let you decide if you like this contribution or not and if you want me to add the keyboard shortcuts, any suggestion is welcome.

Anyway, thanks for this extension. It's really helpful!
