### PR TITLE
Find surrounding word

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.vscode-test
 node_modules

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -47,7 +47,7 @@ function showCommandPalette() {
 }
 
 function toggleBold() {
-    editorHelpers.surroundSelection('**')
+    return editorHelpers.surroundSelection('**')
 }
 
 function toggleItalic() {

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -29,7 +29,7 @@ var _commands = [
 ]
 
 function register(context) {
-    
+
     _commands.map((cmd) => {
         context.subscriptions.push(vscode.commands.registerCommand('md-shortcut.' + cmd.command, cmd.callback))
     })
@@ -41,7 +41,7 @@ function showCommandPalette() {
     })
         .then((cmd) => {
             if (!cmd) return;
-            
+
             cmd.callback();
         })
 }
@@ -51,11 +51,11 @@ function toggleBold() {
 }
 
 function toggleItalic() {
-    editorHelpers.surroundSelection('_')
+    return editorHelpers.surroundSelection('_')
 }
 
 function toggleStrikethrough() {
-    editorHelpers.surroundSelection('~~');
+    return editorHelpers.surroundSelection('~~');
 }
 
 function toggleCodeBlock() {
@@ -63,42 +63,42 @@ function toggleCodeBlock() {
 }
 
 function toggleInlineCode() {
-    editorHelpers.surroundSelection('`')
+    return editorHelpers.surroundSelection('`')
 }
 
 function toggleTitleH1() {
-    editorHelpers.surroundSelection('# ','')
+    return editorHelpers.surroundSelection('# ','')
 }
 
 function toggleTitleH2() {
-    editorHelpers.surroundSelection('## ','')
+    return editorHelpers.surroundSelection('## ','')
 }
 
 function toggleTitleH3() {
-    editorHelpers.surroundSelection('### ','')
+    return editorHelpers.surroundSelection('### ','')
 }
 
 function toggleTitleH4() {
-    editorHelpers.surroundSelection('#### ','')
+    return editorHelpers.surroundSelection('#### ','')
 }
 
 function toggleTitleH5() {
-    editorHelpers.surroundSelection('##### ','')
+    return editorHelpers.surroundSelection('##### ','')
 }
 
 function toggleTitleH6() {
-    editorHelpers.surroundSelection('###### ','')
+    return editorHelpers.surroundSelection('###### ','')
 }
 
 var HasBullets = /^(\s*)\* (.*)$/gm
 var AddBullets = /^(\s*)(.+)$/gm
 function toggleBullets() {
-    
+
     if (!editorHelpers.isAnythingSelected()) {
         editorHelpers.surroundSelection("* ", "")
         return;
     }
-    
+
     if (editorHelpers.isMatch(HasBullets)) {
         editorHelpers.replaceBlockSelection((text) => text.replace(HasBullets, "$1$2"))
     }
@@ -110,12 +110,12 @@ function toggleBullets() {
 var HasNumbers = /^(\s*)[0-9]\.+ (.*)$/gm
 var AddNumbers = /^(\n?)(\s*)(.+)$/gm
 function toggleNumberList() {
-    
+
     if (!editorHelpers.isAnythingSelected()) {
         editorHelpers.surroundSelection("1. ", "")
         return;
     }
-    
+
     if (editorHelpers.isMatch(HasNumbers)) {
         editorHelpers.replaceBlockSelection((text) => text.replace(HasNumbers, "$1$2"))
     }
@@ -133,12 +133,12 @@ function toggleNumberList() {
 var HasCheckboxes = /^(\s*)- \[[ x]{1}\] (.*)$/gm
 var AddCheckboxes = /^(\s*)(.+)$/gm
 function toggleCheckboxes() {
-    
+
     if (!editorHelpers.isAnythingSelected()) {
         editorHelpers.surroundSelection("- [ ]", "")
         return;
     }
-    
+
     if (editorHelpers.isMatch(HasCheckboxes)) {
         editorHelpers.replaceBlockSelection((text) => text.replace(HasCheckboxes, "$1$2"))
     }
@@ -150,7 +150,7 @@ function toggleCheckboxes() {
 const MarkdownLinkRegex = /^\[.+\]\(.+\)$/;
 const UrlRegex = /^(http[s]?:\/\/.+|<http[s]?:\/\/.+>)$/;
 function toggleLink() {
-    
+
     if (editorHelpers.isAnythingSelected()) {
         if (editorHelpers.isMatch(MarkdownLinkRegex)) {
             //Selection is a MD link, replace it with the link text
@@ -167,24 +167,24 @@ function toggleLink() {
 
     var editor = vscode.window.activeTextEditor;
     var selection = editor.selection;
-    
+
     return getLinkText()
         .then(getLinkUrl)
         .then(addTags);
-    
+
     function getLinkText() {
         if (selection.isEmpty) {
             return vscode.window.showInputBox({
                 prompt: "Link text"
             })
         }
-        
+
         return Promise.resolve("")
     }
-    
+
     function getLinkUrl(linkText) {
         if (linkText == null || linkText == undefined) return;
-        
+
         return vscode.window.showInputBox({
                 prompt: "Link URL"
             })
@@ -192,10 +192,10 @@ function toggleLink() {
                 return { text: linkText, url: url}
             })
     }
-    
+
     function addTags(options) {
         if (!options || !options.url) return;
-        
+
         editorHelpers.surroundSelection("[" + options.text, "](" + options.url + ")")
     }
 }
@@ -203,7 +203,7 @@ function toggleLink() {
 
 const MarkdownImageRegex = /!\[.*\]\((.+)\)/;
 function toggleImage() {
-    
+
     var editor = vscode.window.activeTextEditor;
     var selection = editor.selection;
 
@@ -227,24 +227,24 @@ function toggleImage() {
 
     var editor = vscode.window.activeTextEditor;
     var selection = editor.selection;
-    
+
     return getLinkText()
         .then(getLinkUrl)
         .then(addTags);
-    
+
     function getLinkText() {
         if (selection.isEmpty) {
             return vscode.window.showInputBox({
                 prompt: "Image alt text"
             })
         }
-        
+
         return Promise.resolve("")
     }
-    
+
     function getLinkUrl(linkText) {
         if (linkText == null || linkText == undefined) return;
-        
+
         return vscode.window.showInputBox({
                 prompt: "Image URL"
             })
@@ -252,10 +252,10 @@ function toggleImage() {
                 return { text: linkText, url: url}
             })
     }
-    
+
     function addTags(options) {
         if (!options || !options.url) return;
-        
+
         editorHelpers.surroundSelection("![" + options.text, "](" + options.url + ")")
     }
 }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -59,7 +59,7 @@ function toggleStrikethrough() {
 }
 
 function toggleCodeBlock() {
-    editorHelpers.surroundBlockSelection('```\n', '```')
+    return editorHelpers.surroundBlockSelection('```\n', '```')
 }
 
 function toggleInlineCode() {

--- a/lib/editorHelpers.js
+++ b/lib/editorHelpers.js
@@ -43,18 +43,18 @@ function surroundSelection(startPattern, endPattern)
     if (!isAnythingSelected()) {
         var position = selection.active;
         var newPosition = position.with(position.line, position.character + startPattern.length)
-        editor.edit((edit) => {
-            edit.insert(selection.start, startPattern + endPattern);
-        }).then(() => {
-            editor.selection = new vscode.Selection(newPosition, newPosition)
-        })
+        return editor.edit((edit) => {
+                edit.insert(selection.start, startPattern + endPattern);
+            }).then(() => {
+                editor.selection = new vscode.Selection(newPosition, newPosition)
+            })
     }
     else {
         if (isSelectionMatch(selection, startPattern, endPattern)) {
-            replaceSelection((text) => text.substr(startPattern.length, text.length - startPattern.length - endPattern.length))
+            return replaceSelection((text) => text.substr(startPattern.length, text.length - startPattern.length - endPattern.length))
         }
         else {
-            replaceSelection((text) => startPattern + text + endPattern)
+            return replaceSelection((text) => startPattern + text + endPattern)
         }
     }
 }

--- a/lib/editorHelpers.js
+++ b/lib/editorHelpers.js
@@ -39,24 +39,32 @@ function surroundSelection(startPattern, endPattern)
     
     var editor = vscode.window.activeTextEditor;
     var selection = editor.selection;
+
+    var selectionGetter = isAnythingSelected() ?
+        Promise.resolve(selection ) :
+        // Attempt to expand the collapsed selection (#5).
+        vscode.commands.executeCommand('editor.action.addSelectionToNextFindMatch')
+            .then(() => editor.selection );
     
-    if (!isAnythingSelected()) {
-        var position = selection.active;
-        var newPosition = position.with(position.line, position.character + startPattern.length)
-        return editor.edit((edit) => {
-                edit.insert(selection.start, startPattern + endPattern);
-            }).then(() => {
-                editor.selection = new vscode.Selection(newPosition, newPosition)
-            })
-    }
-    else {
-        if (isSelectionMatch(selection, startPattern, endPattern)) {
-            return replaceSelection((text) => text.substr(startPattern.length, text.length - startPattern.length - endPattern.length))
-        }
-        else {
-            return replaceSelection((text) => startPattern + text + endPattern)
-        }
-    }
+    return selectionGetter
+        .then(selection => {
+            // Note, even though we're expanding selection with addSelectionToNextFindMatch, there's still a potential chance
+            // for collapsed, e.g. empty file, or just an empty line.
+            if ( !isAnythingSelected()) {
+                var position = selection.active;
+                var newPosition = position.with(position.line, position.character + startPattern.length)
+                return editor.edit((edit) => {
+                    edit.insert(selection.start, startPattern + endPattern);
+                } ).then(() => {
+                    editor.selection = new vscode.Selection(newPosition, newPosition)
+                } )
+            } else if (isSelectionMatch(selection, startPattern, endPattern)) {
+                return replaceSelection((text) => text.substr(startPattern.length, text.length - startPattern.length - endPattern.length))
+            }
+            else {
+                return replaceSelection((text) => startPattern + text + endPattern)
+            }
+        } );
 }
 
 function surroundBlockSelection(startPattern, endPattern)

--- a/lib/editorHelpers.js
+++ b/lib/editorHelpers.js
@@ -68,25 +68,30 @@ function surroundBlockSelection(startPattern, endPattern)
     
     if (!isAnythingSelected()) {
         var position = selection.active;
-        var newPosition = position.with(position.line, position.character + startPattern.length)
-        editor.edit((edit) => {
-            edit.insert(selection.start, startPattern + endPattern);
-        }).then(() => {
-            editor.selection = new vscode.Selection(newPosition, newPosition)
-        })
+        var newPosition = position.with(position.line + 1, 0)
+        return editor.edit((edit) => {
+                edit.insert(selection.start, startPattern + endPattern);
+            }).then(() => {
+                editor.selection = new vscode.Selection(newPosition, newPosition)
+            })
     }
     else {
         if (isSelectionMatch(selection, startPattern, endPattern)) {
-            replaceBlockSelection((text) => text.substr(startPattern.length, text.length - startPattern.length - endPattern.length))
+            return replaceBlockSelection((text) => text.substr(startPattern.length, text.length - startPattern.length - endPattern.length))
         }
         else {
-            replaceBlockSelection((text) => startPattern + text + endPattern)
+            return replaceBlockSelection((text) => startPattern + text + endPattern)
         }
     }
 }
 
 function getBlockSelection() {
     var selection = vscode.window.activeTextEditor.selection;
+
+    if ( selection.isEmpty ) {
+        return selection;
+    }
+
     return selection
         .with(selection.start.with(undefined, 0),
               selection.end.with(selection.end.line + 1, 0));

--- a/package.json
+++ b/package.json
@@ -316,7 +316,8 @@
         "test": "node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
-        "vscode": "^0.11.0"
+        "vscode": "^0.11.0",
+        "vscode-test-content": "^1.1.0"
     },
 	"homepage": "https://github.com/mdickin/vscode-markdown-shortcuts",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -312,7 +312,8 @@
         }
     },
     "scripts": {
-        "postinstall": "node ./node_modules/vscode/bin/install"
+        "postinstall": "node ./node_modules/vscode/bin/install",
+        "test": "node ./node_modules/vscode/bin/test"
     },
     "devDependencies": {
         "vscode": "^0.11.0"

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -20,6 +20,73 @@ suite( "Bold", function() {
     } );
 } );
 
+suite( "Italic", function() {
+    test( "Ranged selection", function() {
+        return TestCommand( 'toggleItalic', 'Lets make a [fancy} text!', 'Lets make a [_fancy_} text!' );
+    } );
+
+    test( "Collapsed selection", function() {
+        // This is likely to be changed with #5.
+        return TestCommand( 'toggleItalic', 'Lets make a fan^cy text!', 'Lets make a fan_^_cy text!' );
+    } );
+
+    test( "Toggles with ranged selection", function() {
+        return TestCommand( 'toggleItalic', 'Lets make less [_fancy_} text', 'Lets make less [fancy} text' );
+    } );
+} );
+
+suite( "Strike through", function() {
+    test( "Ranged selection", function() {
+        return TestCommand( 'toggleStrikethrough', 'Lets make a [fancy} text!', 'Lets make a [~~fancy~~} text!' );
+    } );
+
+    test( "Collapsed selection", function() {
+        // This is likely to be changed with #5.
+        return TestCommand( 'toggleStrikethrough', 'Lets make a fan^cy text!', 'Lets make a fan~~^~~cy text!' );
+    } );
+
+    test( "Toggles with ranged selection", function() {
+        return TestCommand( 'toggleStrikethrough', 'Lets make less [~~fancy~~} text', 'Lets make less [fancy} text' );
+    } );
+} );
+
+suite( "Inline code", function() {
+    test( "Ranged selection", function() {
+        return TestCommand( 'toggleInlineCode', 'Lets make a [fancy} text!', 'Lets make a [`fancy`} text!' );
+    } );
+
+    test( "Collapsed selection", function() {
+        // This is likely to be changed with #5.
+        return TestCommand( 'toggleInlineCode', 'Lets make a fan^cy text!', 'Lets make a fan`^`cy text!' );
+    } );
+
+    test( "Toggles with ranged selection", function() {
+        return TestCommand( 'toggleInlineCode', 'Lets make less [`fancy`} text', 'Lets make less [fancy} text' );
+    } );
+} );
+
+suite( "Headers", function() {
+    // For headers we'll generate the tests, so that this test suite doesn't get too bloat.
+    for ( let i = 1; i <= 6; i++ ) {
+        suite( 'Level ' + i, function() {
+            var headerMarker = '#'.repeat( i );
+
+            test( "Ranged selection", function() {
+                return TestCommand( `toggleTitleH${i}`, 'Lets make a [fancy} text!', `Lets make a [${headerMarker} fancy} text!` );
+            } );
+
+            test( "Collapsed selection", function() {
+                // This is likely to be changed with #5.
+                return TestCommand( `toggleTitleH${i}`, 'Lets make a fan^cy text!', `Lets make a fan${headerMarker} ^cy text!` );
+            } );
+
+            test( "Toggles with ranged selection", function() {
+                return TestCommand( `toggleTitleH${i}`, `Lets make less [${headerMarker} fancy} text`, 'Lets make less [fancy} text' );
+            } );
+        } );
+    }
+} );
+
 // A helper function that generates test case functions.
 // Both inputContent and expectedContent can include selection string representation.
 // Returns a promise resolving to Promise<TextEditor>.

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -2,7 +2,6 @@
 
 var assert = require( 'assert' );
 var vscode = require( 'vscode' );
-var myExtension = require( '../extension' );
 var vscodeTestContent = require( 'vscode-test-content' );
 
 suite( "Bold", function() {

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -1,45 +1,33 @@
 /* global suite, test */
 
-var assert = require('assert');
-var vscode = require('vscode');
-var myExtension = require('../extension');
-var vscodeTestContent = require('vscode-test-content');
+var assert = require( 'assert' );
+var vscode = require( 'vscode' );
+var myExtension = require( '../extension' );
+var vscodeTestContent = require( 'vscode-test-content' );
 
-suite("Bold", function() {
-    test("Ranged selection", function() {
-        return vscodeTestContent.setWithSelection( 'Lets make a [bold} text!')
-            .then( editor => {
-                var expectedText = 'Lets make a [**bold**} text!';
+suite( "Bold", function() {
+    test( "Ranged selection", function() {
+        return TestCommand( 'toggleBold', 'Lets make a [bold} text!', 'Lets make a [**bold**} text!' );
+    } );
 
-                return vscode.commands.executeCommand( 'md-shortcut.toggleBold' )
-                    .then( () =>
-                        assert.strictEqual( vscodeTestContent.getWithSelection( editor ), expectedText )
-                    );
-             } );
-    });
-
-    test("Collapsed selection", function() {
+    test( "Collapsed selection", function() {
         // This is likely to be changed with #5.
-        return vscodeTestContent.setWithSelection( 'Lets make a bo^ld text!')
-            .then( editor => {
-                var expectedText = 'Lets make a bo**^**ld text!';
+        return TestCommand( 'toggleBold', 'Lets make a bo^ld text!', 'Lets make a bo**^**ld text!' );
+    } );
 
-                return vscode.commands.executeCommand( 'md-shortcut.toggleBold' )
-                    .then( () =>
-                        assert.strictEqual( vscodeTestContent.getWithSelection( editor ), expectedText )
-                    );
-             } );
-    });
+    test( "Toggles with ranged selection", function() {
+        return TestCommand( 'toggleBold', 'Time to [**unbold**} this statement', 'Time to [unbold} this statement' );
+    } );
+} );
 
-    test("Toggles with ranged selection", function() {
-        return vscodeTestContent.setWithSelection( 'Time to [**unbold**} this statement')
-            .then( editor => {
-                var expectedText = 'Time to [unbold} this statement';
-
-                return vscode.commands.executeCommand( 'md-shortcut.toggleBold' )
-                    .then( () =>
-                        assert.strictEqual( vscodeTestContent.getWithSelection( editor ), expectedText )
-                    );
-             } );
-    });
-});
+// A helper function that generates test case functions.
+// Both inputContent and expectedContent can include selection string representation.
+// Returns a promise resolving to Promise<TextEditor>.
+function TestCommand( command, inputContent, expectedContent ) {
+    return vscodeTestContent.setWithSelection( inputContent )
+        .then( editor => {
+            return vscode.commands.executeCommand( 'md-shortcut.' + command )
+                .then(() => assert.strictEqual( vscodeTestContent.getWithSelection( editor ), expectedContent ) )
+                .then(() => editor );
+        } );
+}

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -87,6 +87,20 @@ suite( "Headers", function() {
     }
 } );
 
+suite( "Block code", function() {
+    test( "Ranged selection", function() {
+        return TestCommand( 'toggleCodeBlock', '[some code}', '[```\nsome code```}' );
+    } );
+
+    test( "Collapsed selection", function() {
+        return TestCommand( 'toggleCodeBlock', 'Some code^', 'Some code```\n^```' );
+    } );
+
+    test( "Toggles with ranged selection", function() {
+        return TestCommand( 'toggleCodeBlock', '[```\nsome code```}', '[some code}' );
+    } );
+} );
+
 // A helper function that generates test case functions.
 // Both inputContent and expectedContent can include selection string representation.
 // Returns a promise resolving to Promise<TextEditor>.

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -15,7 +15,20 @@ suite("Bold", function() {
                     .then( () =>
                         assert.strictEqual( vscodeTestContent.getWithSelection( editor ), expectedText )
                     );
-             } )
+             } );
+    });
+
+    test("Collapsed selection", function() {
+        // This is likely to be changed with #5.
+        return vscodeTestContent.setWithSelection( 'Lets make a bo^ld text!')
+            .then( editor => {
+                var expectedText = 'Lets make a bo**^**ld text!';
+
+                return vscode.commands.executeCommand( 'md-shortcut.toggleBold' )
+                    .then( () =>
+                        assert.strictEqual( vscodeTestContent.getWithSelection( editor ), expectedText )
+                    );
+             } );
     });
 
     test("Toggles with ranged selection", function() {
@@ -27,6 +40,6 @@ suite("Bold", function() {
                     .then( () =>
                         assert.strictEqual( vscodeTestContent.getWithSelection( editor ), expectedText )
                     );
-             } )
+             } );
     });
 });

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -11,7 +11,12 @@ suite( "Bold", function() {
 
     test( "Collapsed selection", function() {
         // This is likely to be changed with #5.
-        return TestCommand( 'toggleBold', 'Lets make a bo^ld text!', 'Lets make a bo**^**ld text!' );
+        return TestCommand( 'toggleBold', 'Lets make a bo^ld text!', 'Lets make a [**bold**} text!' );
+    } );
+
+    test( "Collapsed selection empty editor", function() {
+        // make sure nothing wrong happens when the editor is totally empty.
+        return TestCommand( 'toggleBold', '^', '**^**' );
     } );
 
     test( "Toggles with ranged selection", function() {
@@ -26,7 +31,7 @@ suite( "Italic", function() {
 
     test( "Collapsed selection", function() {
         // This is likely to be changed with #5.
-        return TestCommand( 'toggleItalic', 'Lets make a fan^cy text!', 'Lets make a fan_^_cy text!' );
+        return TestCommand( 'toggleItalic', 'Lets make a fan^cy text!', 'Lets make a [_fancy_} text!' );
     } );
 
     test( "Toggles with ranged selection", function() {
@@ -41,7 +46,7 @@ suite( "Strike through", function() {
 
     test( "Collapsed selection", function() {
         // This is likely to be changed with #5.
-        return TestCommand( 'toggleStrikethrough', 'Lets make a fan^cy text!', 'Lets make a fan~~^~~cy text!' );
+        return TestCommand( 'toggleStrikethrough', 'Lets make a fan^cy text!', 'Lets make a [~~fancy~~} text!' );
     } );
 
     test( "Toggles with ranged selection", function() {
@@ -56,7 +61,7 @@ suite( "Inline code", function() {
 
     test( "Collapsed selection", function() {
         // This is likely to be changed with #5.
-        return TestCommand( 'toggleInlineCode', 'Lets make a fan^cy text!', 'Lets make a fan`^`cy text!' );
+        return TestCommand( 'toggleInlineCode', 'Lets make a fan^cy text!', 'Lets make a [`fancy`} text!' );
     } );
 
     test( "Toggles with ranged selection", function() {
@@ -76,7 +81,7 @@ suite( "Headers", function() {
 
             test( "Collapsed selection", function() {
                 // This is likely to be changed with #5.
-                return TestCommand( `toggleTitleH${i}`, 'Lets make a fan^cy text!', `Lets make a fan${headerMarker} ^cy text!` );
+                return TestCommand( `toggleTitleH${i}`, 'Lets make a fan^cy text!', `Lets make a [${headerMarker} fancy} text!` );
             } );
 
             test( "Toggles with ranged selection", function() {

--- a/test/extension.test.js
+++ b/test/extension.test.js
@@ -1,24 +1,32 @@
 /* global suite, test */
 
-//
-// Note: This example test is leveraging the Mocha test framework.
-// Please refer to their documentation on https://mochajs.org/ for help.
-//
-
-// The module 'assert' provides assertion methods from node
 var assert = require('assert');
-
-// You can import and use all API from the 'vscode' module
-// as well as import your extension to test it
 var vscode = require('vscode');
 var myExtension = require('../extension');
+var vscodeTestContent = require('vscode-test-content');
 
-// Defines a Mocha test suite to group tests of similar kind together
-suite("Extension Tests", function() {
+suite("Bold", function() {
+    test("Ranged selection", function() {
+        return vscodeTestContent.setWithSelection( 'Lets make a [bold} text!')
+            .then( editor => {
+                var expectedText = 'Lets make a [**bold**} text!';
 
-    // Defines a Mocha unit test
-    test("Something 1", function() {
-        assert.equal(-1, [1, 2, 3].indexOf(5));
-        assert.equal(-1, [1, 2, 3].indexOf(0));
+                return vscode.commands.executeCommand( 'md-shortcut.toggleBold' )
+                    .then( () =>
+                        assert.strictEqual( vscodeTestContent.getWithSelection( editor ), expectedText )
+                    );
+             } )
+    });
+
+    test("Toggles with ranged selection", function() {
+        return vscodeTestContent.setWithSelection( 'Time to [**unbold**} this statement')
+            .then( editor => {
+                var expectedText = 'Time to [unbold} this statement';
+
+                return vscode.commands.executeCommand( 'md-shortcut.toggleBold' )
+                    .then( () =>
+                        assert.strictEqual( vscodeTestContent.getWithSelection( editor ), expectedText )
+                    );
+             } )
     });
 });


### PR DESCRIPTION
Note that this pull request is based on #16, so you'd want to review the former one as a first.

You'll see that I've used `editor.action.addSelectionToNextFindMatch` command for expanding the selection to the word under the caret - that's what people has been suggesting for this use case, including official VSCode crew on their GH.

It does ok job for this use case, and I didn't want to spend time on tinkering a home-made function.