### PR TITLE
Add setting to italicize with asterisks

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -55,7 +55,8 @@ function toggleBold() {
 
 const toggleItalicPattern = new RegExp('_?' + wordMatch + '*_?')
 function toggleItalic() {
-    return editorHelpers.surroundSelection('_', '_', toggleItalicPattern);
+    var char = vscode.workspace.getConfiguration("markdownShortcuts").italicizeAsterisks ? '*' : '_';
+    return editorHelpers.surroundSelection(char, char, toggleItalicPattern);
 }
 
 const toggleStrikethroughPattern = new RegExp('~{2}' + wordMatch + '*~{2}|' + wordMatch + '+');

--- a/package.json
+++ b/package.json
@@ -53,6 +53,11 @@
                     "type": "boolean",
                     "default": false,
                     "description": "Show image icon in title bar"
+                },
+                "markdownShortcuts.italicizeAsterisks": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Use * instead of _ for italics"
                 }
             }
         },


### PR DESCRIPTION
Resolve #26 by adding a property to italicize text with asterisks instead of underscores (`markdownShortcuts.italicizeAsterisks`).