### PR TITLE
There isn't always an active editor

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -52,7 +52,7 @@ function activate(context) {
     // Triggered with language id change
     vscode.workspace.onDidOpenTextDocument(
         document => {
-            if (activeEditor.document === document) {
+            if (activeEditor && activeEditor.document === document) {
                 toggleMarkdownShortcuts(activeEditor.document.languageId);
             }
         },


### PR DESCRIPTION
I noticed this exception in the dev console:

```
ERR Cannot read property 'document' of undefined: TypeError: Cannot read property 'document' of undefined
	at vscode.workspace.onDidOpenTextDocument.document (<...>\.vscode\extensions\mdickin.markdown-shortcuts-0.10.0\extension.js:55:30)
```