### PR TITLE
add cite icons

### DIFF
--- a/media/icons/quote_black.svg
+++ b/media/icons/quote_black.svg
@@ -1,0 +1,4 @@
+<svg fill="#000000" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M6 17h3l2-4V7H5v6h3zm8 0h3l2-4V7h-6v6h3z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg> 

--- a/media/icons/quote_white.svg
+++ b/media/icons/quote_white.svg
@@ -1,0 +1,4 @@
+<svg fill="#FFFFFF" height="24" viewBox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+    <path d="M6 17h3l2-4V7H5v6h3zm8 0h3l2-4V7h-6v6h3z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg> 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
                     "default": true,
                     "description": "Show italic icon in title bar"
                 },
+                "markdownShortcuts.icons.citations": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show citations icon in title bar"
+                },
                 "markdownShortcuts.icons.strikethrough": {
                     "type": "boolean",
                     "default": true,
@@ -97,6 +102,10 @@
             {
                 "command": "md-shortcut.toggleCitations",
                 "title": "Toggle citations",
+                "icon": {
+                    "dark": "./media/icons/quote_white.svg",
+                    "light": "./media/icons/quote_black.svg"
+                },
                 "category": "Markdown Shortcuts"
             },
             {
@@ -324,6 +333,11 @@
                     "group": "2_markdown_1@7"
                 },
                 {
+                    "command": "md-shortcut.toggleCitations",
+                    "when": "markdownShortcuts:enabled",
+                    "group": "2_markdown_1@8"
+                },
+                {
                     "command": "md-shortcut.toggleBullets",
                     "when": "markdownShortcuts:enabled",
                     "group": "2_markdown_2@1"
@@ -384,6 +398,10 @@
                     "command": "md-shortcut.toggleImage",
                     "when": "markdownShortcuts:enabled && config.markdownShortcuts.icons.image",
                     "group": "navigation@6"
+                },                {
+                    "command": "md-shortcut.toggleCitations",
+                    "when": "markdownShortcuts:enabled && config.markdownShortcuts.icons.citations",
+                    "group": "navigation@7"
                 }
             ]
         }


### PR DESCRIPTION
Add cite icons in media/icons (x24 black+white from material.io, https://material.io/resources/icons/?search=quote&icon=format_quote&style=baseline), and menu item, editor item
