### PR TITLE
Allow toggle link with no URL specified

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -241,7 +241,7 @@ function toggleLink() {
     }
 
     function addTags(options) {
-        if (!options || !options.url) return;
+        if (!options || options.url == undefined) return;
 
         return editorHelpers.surroundSelection("[" + options.text, "](" + options.url + ")");
     }


### PR DESCRIPTION
👋 Here's a slight modification to the link toggler.

This is what the what the prompt text for the URL advises: _Link URL (Press 'Enter' to confirm or 'Escape' to cancel)_

Currently, if I select some text and run the link toggle command, if I don't enter a URL but still press `Enter` (i.e. press `Enter` without entering any text), nothing happens.

Ideally, this should create a markdown link with an empty URL. I use this workflow when I have a many links to create, so I create the link markup first, and then copy and paste in link URLs later.



If a user wants to exit the link creation process, they can still always press `Escape` to exit the prompt without it changing the editor. 