### PR TITLE
Disable shortcuts when the active text editor is undefined

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -41,9 +41,7 @@ function activate(context) {
     vscode.window.onDidChangeActiveTextEditor(
         editor => {
             activeEditor = editor;
-            if (activeEditor) {
-                toggleMarkdownShortcuts(activeEditor.document.languageId);
-            }
+            toggleMarkdownShortcuts(activeEditor?.document.languageId);
         },
         null,
         context.subscriptions


### PR DESCRIPTION
The shortcuts in title bar are still displayed when opening the preview window