### PR TITLE
Factor markdown..orderedList in toggleNumberList()

### DIFF
--- a/lib/commands.js
+++ b/lib/commands.js
@@ -144,8 +144,9 @@ function toggleNumberList() {
     }
     else {
        var lineNums = {};
+       var useOnes = vscode.workspace.getConfiguration('markdown.extension.orderedList').get('marker') == 'one';
        return editorHelpers.replaceBlockSelection((text) => text.replace(AddNumbers, (match, newline, whitespace, line) => {
-            if (!lineNums[whitespace]) {
+            if (!lineNums[whitespace] || useOnes) {
                 lineNums[whitespace] = 1
             }
             return newline + whitespace + lineNums[whitespace]++ + ". " + line


### PR DESCRIPTION
I use both mdickin.markdown-shortcuts and yzhang.markdown-all-in-one extensions.
I set my `Markdown › Extension › Ordered List: Marker` to `one` so that all numbers are entered as `1. ` and
Markdown computes the actual numbers during rendering.
This minimizes renumbering when adding, deleting or reordering the list.
I wanted the shortcut included in this repo to take that setting into account when calling toggleNumberList()
I tested this modification with both settings of `Ordered List: Marker` and
also without having yzhang.markdown-all-in-one installed.

